### PR TITLE
feat: added glazewm's workspace display

### DIFF
--- a/vanilla-clear/vanilla-clear.html
+++ b/vanilla-clear/vanilla-clear.html
@@ -30,6 +30,7 @@
 
       const providers = zebar.createProviderGroup({
         network: { type: "network" },
+        glazewm: { type: "glazewm" },
         cpu: { type: "cpu" },
         date: { type: "date", formatting: "EEE d MMM t" },
         battery: { type: "battery" },
@@ -116,6 +117,23 @@
           <div className="app">
             <div className="left">
               <i className="logo nf nf-fa-windows"></i>
+              {output.glazewm && (
+                <div className="workspaces">
+                  {output.glazewm.currentWorkspaces.map(workspace => (
+                    <button
+                      className={`workspace ${workspace.hasFocus && 'focused'} ${workspace.isDisplayed && 'displayed'}`}
+                      onClick={() =>
+                        output.glazewm.runCommand(
+                          `focus --workspace ${workspace.name}`,
+                        )
+                      }
+                      key={workspace.name}
+                    >
+                      {workspace.displayName ?? workspace.name}
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
 
             <div className="center">{output.date?.formatted}</div>


### PR DESCRIPTION
Added integration with GlazeWM to display open workspaces.

This implementation was copied from the [starter config](https://github.com/glzr-io/zebar/blob/main/examples/starter/with-glazewm.html#L124-L140).

Interestingly, the workspace display configuration was missing, even though it appears to be present in your [video](https://www.youtube.com/watch?v=G0_wVLhI-Ds).